### PR TITLE
Handle PCI domains other than domain 0.

### DIFF
--- a/sysinfo-snapshot.py
+++ b/sysinfo-snapshot.py
@@ -1391,12 +1391,12 @@ def mlxcables_standard_handler():
 def lspci_vv_handler():
     mlnx_pci = [] # A list containing  PCI addresses of Mellanox devices
     result = "Mellanox Pci devices tree \n" # Final result
-    st,res = get_status_output("lspci -nnd 15b3:")
+    st,res = get_status_output("lspci -Dnnd 15b3:")
     if st == 0  and res :
         lines = res.splitlines()
         for line in lines:
             device = line.split()[0]
-            path = os.readlink("/sys/bus/pci/devices/0000:" + device)
+            path = os.readlink("/sys/bus/pci/devices/" + device)
             pci = path.split('/')
             for part in pci:
                 part = part.split(":",1)
@@ -2152,23 +2152,23 @@ def nvsm_dump_health_handler():
 
 def pci_bus_handler():
     res = ""
-    st,result = get_status_output("lspci -nnd ::0302")
+    st,result = get_status_output("lspci -Dnnd ::0302")
     if st == 0  and result :
         lines = result.splitlines()
         res = "Nvidia pci buses \n"
         for line in lines:
             device = line.split()[0]
-            path = os.readlink("/sys/bus/pci/devices/0000:" + device)
+            path = os.readlink("/sys/bus/pci/devices/" + device)
             res += path + "\n"
         res += " RP   |  UP      iDP     iUP     DP   |  UP      iDP     iUP     DP   |  UP      DP   |  EP \n"
         res += "  CPU  |           CDFP Switch         |          Switch Board         | GPU Baseboard |  GPU \n"
-    st,result = get_status_output("lspci -nnd 15b3:")
+    st,result = get_status_output("lspci -Dnnd 15b3:")
     if st == 0  and result :
         lines = result.splitlines()
         res += "Mellanox pci buses \n"
         for line in lines:
             device = line.split()[0]
-            path = os.readlink("/sys/bus/pci/devices/0000:" + device)
+            path = os.readlink("/sys/bus/pci/devices/" + device)
             res += path + "\n"
         res += "  RP   |  UP      iDP     iUP     DP   |  UP      iDP     iUP     DP   |  EP \n"
         res += "  CPU  |           CDFP Switch         |          Switch Board         |  NIC \n"


### PR DESCRIPTION
On a system with more than one PCI domain:

$ /usr/sbin/sysinfo-snapshot.py
Sysinfo-snapshot is still in process...please wait till completed successfully Gathering the information may take a while, especially in large networks Your patience is appreciated
Traceback (most recent call last):
  File "/usr/sbin/sysinfo-snapshot.py", line 5979, in <module>
    main()
  File "/usr/sbin/sysinfo-snapshot.py", line 5976, in main
    execute(parsed_args)
  File "/usr/sbin/sysinfo-snapshot.py", line 5863, in execute
    generate_output()
  File "/usr/sbin/sysinfo-snapshot.py", line 5573, in generate_output
    arrange_dicts()
  File "/usr/sbin/sysinfo-snapshot.py", line 3819, in arrange_dicts
    arrange_server_commands_section()
  File "/usr/sbin/sysinfo-snapshot.py", line 3608, in arrange_server_commands_section
    add_command_if_exists(cmd)
  File "/usr/sbin/sysinfo-snapshot.py", line 2658, in add_command_if_exists
    status, result = pci_bus_handler()
  File "/usr/sbin/sysinfo-snapshot.py", line 2171, in pci_bus_handler
    path = os.readlink("/sys/bus/pci/devices/0000:" + device)
FileNotFoundError: [Errno 2] No such file or directory: '/sys/bus/pci/devices/0000:0001:01:00.0'

The hardcoding of "0000" in the device path assumes that there are no other domains. Prefixing the device path like this would not be necessary if lspci had been run with the '-D' option.